### PR TITLE
Update forbidden words for potentially unsafe query

### DIFF
--- a/src/Oracle.php
+++ b/src/Oracle.php
@@ -98,7 +98,7 @@ class Oracle
         }
 
         $query = strtolower($query);
-        $forbiddenWords = ['insert', 'update', 'delete', 'alter', 'drop', 'truncate', 'create', 'replace'];
+        $forbiddenWords = ['insert', 'update ', 'delete ', 'alter', 'drop', 'truncate', 'create ', 'replace'];
         throw_if(Str::contains($query, $forbiddenWords), PotentiallyUnsafeQuery::fromQuery($query));
     }
 


### PR DESCRIPTION
The words 'update', 'delete' and 'create' produce false positives as a potentially unsafe query as by default Eloquent uses fields like 'created_at', 'updated_at' and 'deleted_at' for timestamps, so by default use a blank space at the end of the 'update', 'delete' and 'create' strings stop producing false positives.