### PR TITLE
Remove Doctrine DBAL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^8.1",
-        "doctrine/dbal": "^3.6",
-        "illuminate/contracts": "^9.0|^10.0",
+        "illuminate/contracts": "^10.0",
+        "illuminate/database": "^10.43",
         "openai-php/laravel": "^0.3.1",
         "spatie/laravel-package-tools": "^1.14.0",
         "spatie/once": "^3.1"

--- a/resources/views/prompts/query.blade.php
+++ b/resources/views/prompts/query.blade.php
@@ -9,7 +9,7 @@ Answer: "Final answer here"
 Only use the following tables and columns:
 
 @foreach($tables as $table)
-"{{ $table->getName() }}" has columns: {{ collect($table->getColumns())->map(fn(\Doctrine\DBAL\Schema\Column $column) => $column->getName() . ' ('.$column->getType()->getName().')')->implode(', ') }}
+"{{ $table }}" has columns: {{ collect(\Illuminate\Support\Facades\Schema::getColumns($table))->map(fn(array $column) => $column['name'] . ' ('.$column['type_name'].')')->implode(', ') }}
 @endforeach
 
 Question: "{!! $question  !!}"

--- a/resources/views/prompts/tables.blade.php
+++ b/resources/views/prompts/tables.blade.php
@@ -1,5 +1,5 @@
 Given the below input question and list of potential tables, output a comma separated list of the table names that may be necessary to answer this question.
 Question: {{ $question }}
-Table Names: @foreach($tables as $table){{ $table->getName() }},@endforeach
+Table Names: @foreach($tables as $table){{ $table }},@endforeach
 
 Relevant Table Names:

--- a/tests/Fixtures/filtered-query-prompt.txt
+++ b/tests/Fixtures/filtered-query-prompt.txt
@@ -1,4 +1,4 @@
-Given an input question, first create a syntactically correct Sqlite query to run, then look at the results of the query and return the answer.
+Given an input question, first create a syntactically correct SQLite query to run, then look at the results of the query and return the answer.
 Use the following format:
 
 Question: "Question here"
@@ -8,7 +8,7 @@ Answer: "Final answer here"
 
 Only use the following tables and columns:
 
-"users" has columns: id (integer), name (string), email (string), email_verified_at (datetime), password (string), remember_token (string), created_at (datetime), updated_at (datetime)
+"users" has columns: id (integer), name (varchar), email (varchar), email_verified_at (datetime), password (varchar), remember_token (varchar), created_at (datetime), updated_at (datetime)
 
 Question: "How many users do you have?"
 SQLQuery: "

--- a/tests/Fixtures/filtered-result-prompt.txt
+++ b/tests/Fixtures/filtered-result-prompt.txt
@@ -1,4 +1,4 @@
-Given an input question, first create a syntactically correct Sqlite query to run, then look at the results of the query and return the answer.
+Given an input question, first create a syntactically correct SQLite query to run, then look at the results of the query and return the answer.
 Use the following format:
 
 Question: "Question here"
@@ -8,7 +8,7 @@ Answer: "Final answer here"
 
 Only use the following tables and columns:
 
-"users" has columns: id (integer), name (string), email (string), email_verified_at (datetime), password (string), remember_token (string), created_at (datetime), updated_at (datetime)
+"users" has columns: id (integer), name (varchar), email (varchar), email_verified_at (datetime), password (varchar), remember_token (varchar), created_at (datetime), updated_at (datetime)
 
 Question: "How many users do you have?"
 SQLQuery: "SELECT COUNT(*) FROM users;"

--- a/tests/Fixtures/query-prompt-l10.txt
+++ b/tests/Fixtures/query-prompt-l10.txt
@@ -1,4 +1,4 @@
-Given an input question, first create a syntactically correct Sqlite query to run, then look at the results of the query and return the answer.
+Given an input question, first create a syntactically correct SQLite query to run, then look at the results of the query and return the answer.
 Use the following format:
 
 Question: "Question here"
@@ -8,10 +8,10 @@ Answer: "Final answer here"
 
 Only use the following tables and columns:
 
-"failed_jobs" has columns: id (integer), uuid (string), connection (text), queue (text), payload (text), exception (text), failed_at (datetime)
-"migrations" has columns: id (integer), migration (string), batch (integer)
-"password_reset_tokens" has columns: email (string), token (string), created_at (datetime)
-"users" has columns: id (integer), name (string), email (string), email_verified_at (datetime), password (string), remember_token (string), created_at (datetime), updated_at (datetime)
+"failed_jobs" has columns: id (integer), uuid (varchar), connection (text), queue (text), payload (text), exception (text), failed_at (datetime)
+"migrations" has columns: id (integer), migration (varchar), batch (integer)
+"password_reset_tokens" has columns: email (varchar), token (varchar), created_at (datetime)
+"users" has columns: id (integer), name (varchar), email (varchar), email_verified_at (datetime), password (varchar), remember_token (varchar), created_at (datetime), updated_at (datetime)
 
 Question: "How many users do you have?"
 SQLQuery: "

--- a/tests/Fixtures/query-prompt.txt
+++ b/tests/Fixtures/query-prompt.txt
@@ -1,4 +1,4 @@
-Given an input question, first create a syntactically correct Sqlite query to run, then look at the results of the query and return the answer.
+Given an input question, first create a syntactically correct SQLite query to run, then look at the results of the query and return the answer.
 Use the following format:
 
 Question: "Question here"
@@ -8,10 +8,10 @@ Answer: "Final answer here"
 
 Only use the following tables and columns:
 
-"failed_jobs" has columns: id (integer), uuid (string), connection (text), queue (text), payload (text), exception (text), failed_at (datetime)
-"migrations" has columns: id (integer), migration (string), batch (integer)
-"password_resets" has columns: email (string), token (string), created_at (datetime)
-"users" has columns: id (integer), name (string), email (string), email_verified_at (datetime), password (string), remember_token (string), created_at (datetime), updated_at (datetime)
+"failed_jobs" has columns: id (integer), uuid (varchar), connection (text), queue (text), payload (text), exception (text), failed_at (datetime)
+"migrations" has columns: id (integer), migration (varchar), batch (integer)
+"password_resets" has columns: email (varchar), token (varchar), created_at (datetime)
+"users" has columns: id (integer), name (varchar), email (varchar), email_verified_at (datetime), password (varchar), remember_token (varchar), created_at (datetime), updated_at (datetime)
 
 Question: "How many users do you have?"
 SQLQuery: "

--- a/tests/Fixtures/result-prompt-l10.txt
+++ b/tests/Fixtures/result-prompt-l10.txt
@@ -1,4 +1,4 @@
-Given an input question, first create a syntactically correct Sqlite query to run, then look at the results of the query and return the answer.
+Given an input question, first create a syntactically correct SQLite query to run, then look at the results of the query and return the answer.
 Use the following format:
 
 Question: "Question here"
@@ -8,10 +8,10 @@ Answer: "Final answer here"
 
 Only use the following tables and columns:
 
-"failed_jobs" has columns: id (integer), uuid (string), connection (text), queue (text), payload (text), exception (text), failed_at (datetime)
-"migrations" has columns: id (integer), migration (string), batch (integer)
-"password_reset_tokens" has columns: email (string), token (string), created_at (datetime)
-"users" has columns: id (integer), name (string), email (string), email_verified_at (datetime), password (string), remember_token (string), created_at (datetime), updated_at (datetime)
+"failed_jobs" has columns: id (integer), uuid (varchar), connection (text), queue (text), payload (text), exception (text), failed_at (datetime)
+"migrations" has columns: id (integer), migration (varchar), batch (integer)
+"password_reset_tokens" has columns: email (varchar), token (varchar), created_at (datetime)
+"users" has columns: id (integer), name (varchar), email (varchar), email_verified_at (datetime), password (varchar), remember_token (varchar), created_at (datetime), updated_at (datetime)
 
 Question: "How many users do you have?"
 SQLQuery: "SELECT COUNT(*) FROM users;"

--- a/tests/Fixtures/result-prompt.txt
+++ b/tests/Fixtures/result-prompt.txt
@@ -1,4 +1,4 @@
-Given an input question, first create a syntactically correct Sqlite query to run, then look at the results of the query and return the answer.
+Given an input question, first create a syntactically correct SQLite query to run, then look at the results of the query and return the answer.
 Use the following format:
 
 Question: "Question here"
@@ -8,10 +8,10 @@ Answer: "Final answer here"
 
 Only use the following tables and columns:
 
-"failed_jobs" has columns: id (integer), uuid (string), connection (text), queue (text), payload (text), exception (text), failed_at (datetime)
-"migrations" has columns: id (integer), migration (string), batch (integer)
-"password_resets" has columns: email (string), token (string), created_at (datetime)
-"users" has columns: id (integer), name (string), email (string), email_verified_at (datetime), password (string), remember_token (string), created_at (datetime), updated_at (datetime)
+"failed_jobs" has columns: id (integer), uuid (varchar), connection (text), queue (text), payload (text), exception (text), failed_at (datetime)
+"migrations" has columns: id (integer), migration (varchar), batch (integer)
+"password_resets" has columns: email (varchar), token (varchar), created_at (datetime)
+"users" has columns: id (integer), name (varchar), email (varchar), email_verified_at (datetime), password (varchar), remember_token (varchar), created_at (datetime), updated_at (datetime)
 
 Question: "How many users do you have?"
 SQLQuery: "SELECT COUNT(*) FROM users;"

--- a/tests/Fixtures/unsafe-query-prompt-l10.txt
+++ b/tests/Fixtures/unsafe-query-prompt-l10.txt
@@ -1,4 +1,4 @@
-Given an input question, first create a syntactically correct Sqlite query to run, then look at the results of the query and return the answer.
+Given an input question, first create a syntactically correct SQLite query to run, then look at the results of the query and return the answer.
 Use the following format:
 
 Question: "Question here"
@@ -8,10 +8,10 @@ Answer: "Final answer here"
 
 Only use the following tables and columns:
 
-"failed_jobs" has columns: id (integer), uuid (string), connection (text), queue (text), payload (text), exception (text), failed_at (datetime)
-"migrations" has columns: id (integer), migration (string), batch (integer)
-"password_reset_tokens" has columns: email (string), token (string), created_at (datetime)
-"users" has columns: id (integer), name (string), email (string), email_verified_at (datetime), password (string), remember_token (string), created_at (datetime), updated_at (datetime)
+"failed_jobs" has columns: id (integer), uuid (varchar), connection (text), queue (text), payload (text), exception (text), failed_at (datetime)
+"migrations" has columns: id (integer), migration (varchar), batch (integer)
+"password_reset_tokens" has columns: email (varchar), token (varchar), created_at (datetime)
+"users" has columns: id (integer), name (varchar), email (varchar), email_verified_at (datetime), password (varchar), remember_token (varchar), created_at (datetime), updated_at (datetime)
 
 Question: "How many users do you have?"
 SQLQuery: "DROP TABLE users;"

--- a/tests/Fixtures/unsafe-query-prompt.txt
+++ b/tests/Fixtures/unsafe-query-prompt.txt
@@ -1,4 +1,4 @@
-Given an input question, first create a syntactically correct Sqlite query to run, then look at the results of the query and return the answer.
+Given an input question, first create a syntactically correct SQLite query to run, then look at the results of the query and return the answer.
 Use the following format:
 
 Question: "Question here"
@@ -8,10 +8,10 @@ Answer: "Final answer here"
 
 Only use the following tables and columns:
 
-"failed_jobs" has columns: id (integer), uuid (string), connection (text), queue (text), payload (text), exception (text), failed_at (datetime)
-"migrations" has columns: id (integer), migration (string), batch (integer)
-"password_resets" has columns: email (string), token (string), created_at (datetime)
-"users" has columns: id (integer), name (string), email (string), email_verified_at (datetime), password (string), remember_token (string), created_at (datetime), updated_at (datetime)
+"failed_jobs" has columns: id (integer), uuid (varchar), connection (text), queue (text), payload (text), exception (text), failed_at (datetime)
+"migrations" has columns: id (integer), migration (varchar), batch (integer)
+"password_resets" has columns: email (varchar), token (varchar), created_at (datetime)
+"users" has columns: id (integer), name (varchar), email (varchar), email_verified_at (datetime), password (varchar), remember_token (varchar), created_at (datetime), updated_at (datetime)
 
 Question: "How many users do you have?"
 SQLQuery: "DROP TABLE users;"


### PR DESCRIPTION
Doctrine DBAL is [removed on Laravel 11.x](https://github.com/laravel/framework/pull/48864); Therfore, this PR uses native schema methods instead:

* `Schema::getTables()` (L10.34)
* `Schema::getColumns($table)` (L10.37)
* `Schema::getTableListing()` (L10.43)

PS: This PR drops support for Laravel 9.x (end-of-life) and is a starting point to support Laravel 11.x on this package.

Fixes #1 
Fixes #6 
Fixes #17 